### PR TITLE
Fix failing GH Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,8 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/upload-pages-artifact@v1
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v3
         with:
+          name: github-pages
           path: '.'
   deploy:
     needs: build
@@ -31,3 +33,5 @@ jobs:
     steps:
       - uses: actions/deploy-pages@v1
         id: deploy
+        with:
+          artifact_name: github-pages


### PR DESCRIPTION
## Summary
- update workflow to use `upload-artifact` directly and pass artifact name to `deploy-pages`

## Testing
- `npm test` *(fails: package.json missing)*