### PR TITLE
Load host categories from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ To enable Pages on your fork:
 3. Choose **GitHub Actions** as the source and save.
 
 After the workflow runs successfully, the tester will be available at `https://<username>.github.io/<repository>/`.
+
+## Customizing Host Categories
+
+The list of hosts that are tested is stored in `categories.json`. Each entry in
+the JSON file has a `name` and an array of `hosts` URLs. You can add new
+categories or remove hosts by editing this file as long as the JSON structure is
+kept intact. The page will fetch `categories.json` at runtime, so any changes
+take effect the next time the page is loaded.

--- a/categories.json
+++ b/categories.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "Advertising",
+    "hosts": [
+      "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js",
+      "https://adservice.google.com/adsid/integrator.js",
+      "https://static.doubleclick.net/adx/js/impl.js",
+      "https://securepubads.g.doubleclick.net/tag/js/gpt.js"
+    ]
+  },
+  {
+    "name": "Analytics / Trackers",
+    "hosts": [
+      "https://www.google-analytics.com/analytics.js",
+      "https://stats.g.doubleclick.net/dc.js",
+      "https://cdn.segment.com/analytics.js/v1/foobar",
+      "https://ssl.google-analytics.com/ga.js"
+    ]
+  },
+  {
+    "name": "Social Widgets",
+    "hosts": [
+      "https://connect.facebook.net/en_US/sdk.js",
+      "https://static.ads-twitter.com/uwt.js",
+      "https://platform.linkedin.com/in.js"
+    ]
+  }
+]

--- a/index.html
+++ b/index.html
@@ -57,35 +57,9 @@
 
   <script>
     /* List is intentionally short & focused so the page loads fast.
-       You can extend it by editing categories below.                */
-    const categories = [
-      {
-        name: 'Advertising',
-        hosts: [
-          'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js',
-          'https://adservice.google.com/adsid/integrator.js',
-          'https://static.doubleclick.net/adx/js/impl.js',
-          'https://securepubads.g.doubleclick.net/tag/js/gpt.js'
-        ]
-      },
-      {
-        name: 'Analytics / Trackers',
-        hosts: [
-          'https://www.google-analytics.com/analytics.js',
-          'https://stats.g.doubleclick.net/dc.js',
-          'https://cdn.segment.com/analytics.js/v1/foobar',
-          'https://ssl.google-analytics.com/ga.js'
-        ]
-      },
-      {
-        name: 'Social Widgets',
-        hosts: [
-          'https://connect.facebook.net/en_US/sdk.js',
-          'https://static.ads-twitter.com/uwt.js',
-          'https://platform.linkedin.com/in.js'
-        ]
-      }
-    ];
+       Edit `categories.json` to modify the hosts that get tested.   */
+
+    let categories = [];
 
     const resultsEl = document.getElementById('results');
 
@@ -104,7 +78,11 @@
       resultsEl.appendChild(wrapper);
     };
 
-    categories.forEach(createCategorySection);
+    const loadCategories = async () => {
+      const res = await fetch('categories.json');
+      categories = await res.json();
+      categories.forEach(createCategorySection);
+    };
 
     let tested = 0;
     let blocked = 0;
@@ -138,7 +116,7 @@
       summary.textContent = `Blocked ${blocked} / ${tested} (${pct}%)`;
     };
 
-    run();
+    loadCategories().then(run);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move host categories into a new `categories.json`
- fetch the JSON at runtime instead of embedding the array
- document how to change `categories.json`

## Testing
- `npm test` *(fails: could not find package.json)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Host categories and their associated URLs are now managed externally via a configurable JSON file, allowing users to easily customize which hosts are tested.
- **Documentation**
  - Updated documentation with instructions on how to modify host categories and hosts by editing the new JSON configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->