### PR TITLE
Fix GitHub Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,9 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Upload site artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: github-pages
           path: '.'
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- fix GitHub Pages build error by using `actions/upload-pages-artifact@v1`

## Testing
- `git status --short`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Pages deployment workflow to use a specialized upload action for site artifacts. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->