### PR TITLE
Add link to live tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a lightweight ad‑block detection tester that can be hosted using [GitHub Pages](https://pages.github.com/).
 
+You can try the live tester at [kristopherkubicki.github.io/adblock-tester](https://kristopherkubicki.github.io/adblock-tester/).
+
 The GitHub Actions workflow in `.github/workflows/pages.yml` automatically publishes the contents of the repository to GitHub Pages whenever changes are pushed to the `main` branch.
 
 To enable Pages on your fork:


### PR DESCRIPTION
## Summary
- update README with a link to the live GitHub Pages site

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6839c5098d388333b196f36eb0740175