### PR TITLE
Refactor DOM creation to avoid innerHTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,17 @@
       cat.hosts.forEach((h) => {
         const row = document.createElement('div');
         row.className = 'host';
-        row.innerHTML = `<span>${h.replace(/https?:\/\//,'')}</span><span class="status" data-host="${h}">…</span>`;
+
+        const hostSpan = document.createElement('span');
+        hostSpan.textContent = h.replace(/^https?:\/\//, '');
+
+        const statusSpan = document.createElement('span');
+        statusSpan.className = 'status';
+        statusSpan.dataset.host = h;
+        statusSpan.textContent = '…';
+
+        row.appendChild(hostSpan);
+        row.appendChild(statusSpan);
         wrapper.appendChild(row);
       });
       resultsEl.appendChild(wrapper);


### PR DESCRIPTION
## Summary
- build DOM elements explicitly in `createCategorySection`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683cfc7f286c8333af84d5eaaa68195c