### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ categories or remove hosts by editing this file as long as the JSON structure is
 kept intact. The page will fetch `categories.json` at runtime, so any changes
 take effect the next time the page is loaded.
 
-You can also specify aditional hosts at runtime. Use the **Custom host(s)**
+You can also specify additional hosts at runtime. Use the **Custom host(s)**
 field on the tester page or provide a comma‑separated list via the `custom`
 query parameter:
 


### PR DESCRIPTION
## Summary
- fix README typo: additional

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6865645a0b008333ac9adc56e2b47e00