### PR TITLE
Add node tests for categories loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ query parameter:
 ```
 https://<username>.github.io/<repository>/?custom=https://example.com/ad.js
 ```
+
+## Running Tests
+
+The repository includes a small Node-based test suite using the built-in
+`node:test` framework. Run it with:
+
+```
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "adblock-tester",
+  "version": "1.0.0",
+  "description": "This repository contains a lightweight ad‑block detection tester that can be hosted using [GitHub Pages](https://pages.github.com/).",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+const { test } = require('node:test');
+
+const root = __dirname ? path.resolve(__dirname, '..') : '..';
+const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const script = /<script>([\s\S]*?)<\/script>/.exec(html)[1];
+const cleaned = script.replace(/loadCategories\(\)\.then\(run\);/, '');
+const wrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories };`;
+
+const dummy = () => ({
+  appendChild() {},
+  addEventListener() {},
+  classList: { add() {} },
+  set innerHTML(_) {},
+  get innerHTML() { return ''; },
+  set textContent(_) {},
+  get textContent() { return ''; },
+});
+
+function setup(query, data) {
+  const document = {
+    getElementById: () => dummy(),
+    createElement: () => dummy(),
+    querySelector: () => dummy(),
+  };
+  const location = new URL('https://example.com/' + query);
+  const env = {
+    window: undefined,
+    document,
+    location,
+    URLSearchParams,
+    fetch: () => Promise.resolve({ json: () => Promise.resolve(data) }),
+    Image: class { set src(_) { this.onload && this.onload(); } },
+    setTimeout,
+    clearTimeout,
+    console,
+  };
+  const fn = new Function(
+    'window',
+    'document',
+    'location',
+    'URLSearchParams',
+    'fetch',
+    'Image',
+    'setTimeout',
+    'clearTimeout',
+    'console',
+    wrapper,
+  );
+  return fn(
+    env.window,
+    env.document,
+    env.location,
+    env.URLSearchParams,
+    env.fetch,
+    env.Image,
+    env.setTimeout,
+    env.clearTimeout,
+    env.console,
+  );
+}
+
+const categoriesData = JSON.parse(
+  fs.readFileSync(path.join(root, 'categories.json'), 'utf8')
+);
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+test('loads categories.json without custom param', async () => {
+  const { loadCategories, getCategories } = setup('', clone(categoriesData));
+  await loadCategories();
+  assert.deepStrictEqual(getCategories(), categoriesData);
+});
+
+test('appends custom hosts when query param present', async () => {
+  const custom = ['https://example.com/ad.js'];
+  const { loadCategories, getCategories } = setup(
+    '?custom=' + encodeURIComponent(custom.join(',')),
+    clone(categoriesData),
+  );
+  await loadCategories();
+  const expected = clone(categoriesData);
+  expected.push({ name: 'Custom Hosts', hosts: custom });
+  assert.deepStrictEqual(getCategories(), expected);
+});


### PR DESCRIPTION
## Summary
- add node-based unit tests using built-in `node:test`
- expose `npm test` command
- document how to run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865645aff8483338e67d2d1d18c482c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Running Tests" section to the README with instructions for running the test suite.

* **Chores**
  * Introduced a package configuration file with project metadata and a test script.

* **Tests**
  * Added a test suite to verify category loading behavior and handling of custom query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->