### PR TITLE
Add EasyList update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ query parameter:
 ```
 https://<username>.github.io/<repository>/?custom=https://example.com/ad.js
 ```
+
+## Updating Categories from EasyList
+
+Run the helper script to download host lists and regenerate `categories.json`:
+
+```bash
+python scripts/update_categories.py
+```
+
+The script fetches several EasyList sources, extracts the hostnames and writes
+them to `categories.json`. A network connection is required when running it.
+

--- a/scripts/update_categories.py
+++ b/scripts/update_categories.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+import requests
+
+# Sources for each category of hosts. These lists are pulled from
+# publicly available EasyList projects. The lists contain filters in
+# Adblock Plus format; this script extracts just the domain names.
+CATEGORY_SOURCES = {
+    "Advertising": [
+        "https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist_adservers.txt",
+    ],
+    "Analytics / Trackers": [
+        "https://raw.githubusercontent.com/easylist/easylist/master/easyprivacy/easyprivacy_trackingservers.txt",
+    ],
+    "Social Widgets": [
+        "https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist_social.txt",
+    ],
+}
+
+HOST_RE = re.compile(r"^(?:0\.0\.0\.0\s+|127\.0\.0\.1\s+)?")
+FILTER_RE = re.compile(r"\^.*$")
+
+
+def _parse_lines(lines: Iterable[str]) -> list[str]:
+    """Parse host rules from a list of lines."""
+    hosts: list[str] = []
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("!"):
+            continue
+        line = HOST_RE.sub("", line)
+        line = line.lstrip("||")
+        line = FILTER_RE.sub("", line)
+        line = line.split("/")[0]
+        if line:
+            hosts.append(f"https://{line}")
+    return hosts
+
+
+def update_categories(categories_path: Path) -> None:
+    """Download host lists and write ``categories.json``."""
+
+    categories = []
+    for name, urls in CATEGORY_SOURCES.items():
+        hosts: list[str] = []
+        for url in urls:
+            resp = requests.get(url, timeout=30)
+            resp.raise_for_status()
+            hosts.extend(_parse_lines(resp.text.splitlines()))
+        categories.append({"name": name, "hosts": sorted(set(hosts))})
+
+    categories_path.write_text(json.dumps(categories, indent=2))
+
+
+if __name__ == "__main__":
+    update_categories(Path(__file__).resolve().parent.parent / "categories.json")


### PR DESCRIPTION
## Summary
- add `update_categories.py` to fetch hosts from EasyList
- document script usage in README

## Testing
- `pytest -q`
- `mypy scripts/update_categories.py` *(fails: Library stubs not installed for "requests")*
- `bandit -r scripts/update_categories.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656558805c8333a6d7eb4ec10795f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a script to automate updating host categories from EasyList sources.
* **Documentation**
  * Added instructions to the README on how to update categories using the new script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->