### PR TITLE
Fix pages workflow artifact action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
   deploy:


### PR DESCRIPTION
## Summary
- bump `upload-pages-artifact` action to v3 to address deprecation warning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a7294e7b88333a828f1da143b3ec1