### PR TITLE
Add retry and ignore options to update_categories

### DIFF
--- a/scripts/update_categories.py
+++ b/scripts/update_categories.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Iterable
 
 import requests
+from requests import RequestException
 
 # Sources for each category of hosts. These lists are pulled from
 # publicly available EasyList projects. The lists contain filters in
@@ -42,20 +45,60 @@ def _parse_lines(lines: Iterable[str]) -> list[str]:
     return hosts
 
 
-def update_categories(categories_path: Path) -> None:
+def update_categories(
+    categories_path: Path, *, max_retries: int = 1, ignore_failures: bool = False
+) -> None:
     """Download host lists and write ``categories.json``."""
 
     categories = []
     for name, urls in CATEGORY_SOURCES.items():
         hosts: list[str] = []
         for url in urls:
-            resp = requests.get(url, timeout=30)
-            resp.raise_for_status()
-            hosts.extend(_parse_lines(resp.text.splitlines()))
+            attempt = 0
+            while attempt < max_retries:
+                try:
+                    resp = requests.get(url, timeout=30)
+                    resp.raise_for_status()
+                except RequestException as exc:  # network or HTTP error
+                    attempt += 1
+                    logging.warning(
+                        "Failed to fetch %s (attempt %s/%s): %s",
+                        url,
+                        attempt,
+                        max_retries,
+                        exc,
+                    )
+                    if attempt >= max_retries:
+                        if ignore_failures:
+                            break
+                        raise
+                else:
+                    hosts.extend(_parse_lines(resp.text.splitlines()))
+                    break
         categories.append({"name": name, "hosts": sorted(set(hosts))})
 
     categories_path.write_text(json.dumps(categories, indent=2))
 
 
 if __name__ == "__main__":
-    update_categories(Path(__file__).resolve().parent.parent / "categories.json")
+    parser = argparse.ArgumentParser(description="Update category host lists")
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=1,
+        help="Number of times to retry failed downloads",
+    )
+    parser.add_argument(
+        "--ignore-failures",
+        action="store_true",
+        help="Skip sources that fail even after retries",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    update_categories(
+        Path(__file__).resolve().parent.parent / "categories.json",
+        max_retries=args.max_retries,
+        ignore_failures=args.ignore_failures,
+    )


### PR DESCRIPTION
## Summary
- handle RequestException in update_categories
- log a warning and optionally ignore failures
- add command-line options for retries and ignoring failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a7d46636883338b35c4765331d9ec