### PR TITLE
Refactor DOM creation to avoid innerHTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,18 @@
       cat.hosts.forEach((h) => {
         const row = document.createElement('div');
         row.className = 'host';
-        row.innerHTML = `<span>${h.replace(/https?:\/\//,'')}</span><span class="status" data-host="${h}">…</span>`;
+        const hostSpan = document.createElement('span');
+        hostSpan.textContent = h.replace(/https?:\/?\//, '');
+        const statusSpan = document.createElement('span');
+        statusSpan.className = 'status';
+        if (statusSpan.setAttribute) {
+          statusSpan.setAttribute('data-host', h);
+        } else {
+          statusSpan['data-host'] = h;
+        }
+        statusSpan.textContent = '…';
+        row.appendChild(hostSpan);
+        row.appendChild(statusSpan);
         wrapper.appendChild(row);
       });
       resultsEl.appendChild(wrapper);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,7 @@ const dummy = () => ({
   appendChild() {},
   addEventListener() {},
   classList: { add() {} },
+  setAttribute() {},
   set innerHTML(_) {},
   get innerHTML() { return ''; },
   set textContent(_) {},


### PR DESCRIPTION
## Summary
- replace `innerHTML` with safe DOM node creation in `index.html`
- adjust tests for new `setAttribute` usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a7d4857d48333a9ba49c58829b381