### PR TITLE
Add build metadata footer

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,10 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # ▽ build your site here if needed ▽
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: node scripts/add_build_info.js
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'   # static site output
+          path: "." # static site output
 
   deploy:
     needs: build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This repository contains a lightweight ad‑block detection tester that can be hosted using [GitHub Pages](https://pages.github.com/).",
   "main": "index.js",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "build": "node scripts/add_build_info.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/add_build_info.js
+++ b/scripts/add_build_info.js
@@ -1,0 +1,36 @@
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+function getCommitHash() {
+  try {
+    return execSync("git rev-parse --short HEAD").toString().trim();
+  } catch (err) {
+    return "unknown";
+  }
+}
+
+function getBuildTime() {
+  return new Date().toISOString();
+}
+
+function getVersion() {
+  try {
+    const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+    return pkg.version || "0.0.0";
+  } catch (err) {
+    return "0.0.0";
+  }
+}
+
+function updateIndexHtml() {
+  const file = "index.html";
+  let html = fs.readFileSync(file, "utf8");
+  // Remove any existing build-info block
+  html = html.replace(/\n?\s*<div id="build-info"[\s\S]*?<\/div>/, "");
+  const info = `Version ${getVersion()} \u2013 commit ${getCommitHash()} \u2013 built ${getBuildTime()}`;
+  const injection = `\n  <div id="build-info" style="text-align:center;font-size:.75rem;opacity:.6;">${info}</div>`;
+  const updated = html.replace(/(<\/body>)/i, `${injection}\n$1`);
+  fs.writeFileSync(file, updated);
+}
+
+updateIndexHtml();


### PR DESCRIPTION
## Summary
- generate a footer with build info
- inject it during the Pages workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a7db6a6908333b06fc70e19b06b8f