### PR TITLE
Add badges and Codecov integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,9 @@ jobs:
           else
             npm install
           fi
-      - name: Run tests
+      - name: Run tests with coverage
         run: npm test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ package-lock.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+coverage/
 
 # OS-specific files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Adblock Tester
 
+[![CI](https://github.com/kristopherkubicki/adblock-tester/actions/workflows/test.yml/badge.svg)](https://github.com/kristopherkubicki/adblock-tester/actions/workflows/test.yml)
+[![Deploy](https://github.com/kristopherkubicki/adblock-tester/actions/workflows/pages.yml/badge.svg)](https://github.com/kristopherkubicki/adblock-tester/actions/workflows/pages.yml)
+[![codecov](https://codecov.io/gh/kristopherkubicki/adblock-tester/branch/main/graph/badge.svg)](https://codecov.io/gh/kristopherkubicki/adblock-tester)
+
 This repository contains a lightweight ad‑block detection tester that can be hosted using [GitHub Pages](https://pages.github.com/).
 
 You can try the live tester at [kristopherkubicki.github.io/adblock-tester](https://kristopherkubicki.github.io/adblock-tester/).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This repository contains a lightweight ad‑block detection tester that can be hosted using [GitHub Pages](https://pages.github.com/).",
   "scripts": {
-    "test": "node --test",
+    "test": "c8 node --test",
     "update-categories": "python scripts/update_categories.py"
   },
   "keywords": [],
@@ -13,5 +13,8 @@
   },
   "author": "Kristopher Kubicki",
   "license": "MIT",
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "c8": "^8.0.1"
+  }
 }


### PR DESCRIPTION
## Summary
- show CI, deploy and coverage badges in README
- collect coverage with `c8` and upload using Codecov action
- keep coverage directory out of Git

## Testing
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a81d7f3f88333855e413d874fba56