### PR TITLE
Improve visibility of live tester link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository contains a lightweight ad‑block detection tester that can be hosted using [GitHub Pages](https://pages.github.com/).
 
-You can try the live tester at [kristopherkubicki.github.io/adblock-tester](https://kristopherkubicki.github.io/adblock-tester/).
+## [Try the Live Tester](https://kristopherkubicki.github.io/adblock-tester/)
 
 The GitHub Actions workflow in `.github/workflows/pages.yml` automatically publishes the contents of the repository to GitHub Pages whenever changes are pushed to the `main` branch.
 


### PR DESCRIPTION
## Summary
- highlight the tester URL with a bigger heading in the README

## Testing
- `npm test` *(fails: `c8: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a84118b6883339227f7d20b0d1e11