### PR TITLE
Add Python tests and codecov upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Test Suite
 
 on:
   push:
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -22,8 +26,11 @@ jobs:
           else
             npm install
           fi
-      - name: Run tests with coverage
+          pip install -r requirements.txt pytest pytest-cov
+      - name: Run Node tests with coverage
         run: npm test
+      - name: Run Python tests with coverage
+        run: pytest --cov=scripts/update_categories.py --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ them to `categories.json`. A network connection is required when running it.
 
 ## Running Tests
 
-The repository includes a small Node-based test suite using the built-in
-`node:test` framework. Run it with:
+The repository includes Node and Python tests. Run them with coverage using:
 
 ```
 npm test
+pytest --cov=scripts/update_categories.py
 ```
 
 ## License

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,13 @@
+import sys
+import types
+
+# Provide a minimal stub of the requests module so the script can be imported
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+    requests_stub.RequestException = Exception
+
+    def _missing(*_, **__):
+        raise NotImplementedError
+
+    requests_stub.get = _missing
+    sys.modules["requests"] = requests_stub

--- a/test/test_update_categories.py
+++ b/test/test_update_categories.py
@@ -1,0 +1,56 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parent.parent
+if str(BASE) not in sys.path:
+    sys.path.insert(0, str(BASE))
+
+# reload module after inserting our stub
+uc = importlib.import_module("scripts.update_categories")
+
+
+def test_parse_lines_basic():
+    lines = [
+        "||example.com^",
+        "||ads.example.net^$third-party",
+        "127.0.0.1 tracker.example.org",
+        "0.0.0.0 ads.example.org",
+        "! comment",
+        "",
+    ]
+    expected = [
+        "https://example.com",
+        "https://ads.example.net",
+        "https://tracker.example.org",
+        "https://ads.example.org",
+    ]
+    assert uc._parse_lines(lines) == expected
+
+
+class DummyResp:
+    def __init__(self, text, status=200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise uc.requests.RequestException("error")
+
+
+def test_update_categories(tmp_path, monkeypatch):
+    content = "||bad.com^\ntracker.net"
+
+    def fake_get(url, timeout=30):
+        return DummyResp(content)
+
+    monkeypatch.setattr(uc, "CATEGORY_SOURCES", {"Demo": ["http://example.com"]})
+    monkeypatch.setattr(uc.requests, "get", fake_get)
+
+    out = tmp_path / "categories.json"
+    uc.update_categories(out)
+    data = json.loads(out.read_text())
+    assert data == [
+        {"name": "Demo", "hosts": ["https://bad.com", "https://tracker.net"]}
+    ]


### PR DESCRIPTION
## Summary
- add Python tests for update_categories
- upload both Python and Node coverage in CI
- document how to run tests locally

## Testing
- `pytest -q`
- `node --test test/index.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686a83ff24248333bb4919dc3fa5dd32