### PR TITLE
Increase DOM test coverage

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,6 +15,9 @@ const dummy = () => ({
   addEventListener() {},
   classList: { add() {} },
   setAttribute() {},
+  style: { width: 0, height: 0 },
+  width: 0,
+  height: 0,
   set innerHTML(_) {},
   get innerHTML() {
     return "";

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,13 +1,13 @@
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-const assert = require('assert');
-const { test } = require('node:test');
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const assert = require("assert");
+const { test } = require("node:test");
 
-const root = __dirname ? path.resolve(__dirname, '..') : '..';
-const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const root = __dirname ? path.resolve(__dirname, "..") : "..";
+const html = fs.readFileSync(path.join(root, "index.html"), "utf8");
 const script = /<script>([\s\S]*?)<\/script>/.exec(html)[1];
-const cleaned = script.replace(/loadCategories\(\)\.then\(run\);/, '');
+const cleaned = script.replace(/loadCategories\(\)\.then\(run\);/, "");
 const wrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories, sanitizeHost, createCategorySection, run, TIMEOUT_MS };`;
 
 const dummy = () => ({
@@ -16,9 +16,13 @@ const dummy = () => ({
   classList: { add() {} },
   setAttribute() {},
   set innerHTML(_) {},
-  get innerHTML() { return ''; },
+  get innerHTML() {
+    return "";
+  },
   set textContent(_) {},
-  get textContent() { return ''; },
+  get textContent() {
+    return "";
+  },
 });
 
 function setup(query, data) {
@@ -27,7 +31,7 @@ function setup(query, data) {
     createElement: () => dummy(),
     querySelector: () => dummy(),
   };
-  const location = new URL('https://example.com/' + query);
+  const location = new URL("https://example.com/" + query);
   const env = {
     window: undefined,
     document,
@@ -35,8 +39,12 @@ function setup(query, data) {
     URLSearchParams,
     fetch: () => Promise.resolve({ json: () => Promise.resolve(data) }),
     Image: class {
+      constructor() {
+        this.width = 0;
+        this.height = 0;
+      }
       set src(url) {
-        if (url.includes('blocked')) {
+        if (url.includes("blocked")) {
           this.onerror && this.onerror();
         } else {
           this.onload && this.onload();
@@ -48,15 +56,15 @@ function setup(query, data) {
     console,
   };
   const fn = new Function(
-    'window',
-    'document',
-    'location',
-    'URLSearchParams',
-    'fetch',
-    'Image',
-    'setTimeout',
-    'clearTimeout',
-    'console',
+    "window",
+    "document",
+    "location",
+    "URLSearchParams",
+    "fetch",
+    "Image",
+    "setTimeout",
+    "clearTimeout",
+    "console",
     wrapper,
   );
   return fn(
@@ -73,7 +81,7 @@ function setup(query, data) {
 }
 
 const categoriesData = JSON.parse(
-  fs.readFileSync(path.join(root, 'categories.json'), 'utf8')
+  fs.readFileSync(path.join(root, "categories.json"), "utf8"),
 );
 
 function clone(obj) {
@@ -84,44 +92,58 @@ function setupSpy(query, data, hooks = {}) {
   let spans = [];
   let innerHTMLUsed = false;
   const summaryEl = dummy();
-  Object.defineProperty(summaryEl, 'textContent', {
-    set(v) { summaryEl._text = v; },
-    get() { return summaryEl._text; },
+  Object.defineProperty(summaryEl, "textContent", {
+    set(v) {
+      summaryEl._text = v;
+    },
+    get() {
+      return summaryEl._text;
+    },
   });
   const document = {
-    getElementById: (id) => (id === 'summary' ? summaryEl : dummy()),
+    getElementById: (id) => (id === "summary" ? summaryEl : dummy()),
     createElement: (tag) => {
       const el = {
         tag,
         attrs: {},
         classList: {
           added: [],
-          add(c) { this.added.push(c); },
+          add(c) {
+            this.added.push(c);
+          },
         },
         appendChild() {},
-        setAttribute(name, value) { this.attrs[name] = value; },
+        setAttribute(name, value) {
+          this.attrs[name] = value;
+        },
       };
-      Object.defineProperty(el, 'textContent', {
-        set(v) { el._text = v; },
-        get() { return el._text; },
+      Object.defineProperty(el, "textContent", {
+        set(v) {
+          el._text = v;
+        },
+        get() {
+          return el._text;
+        },
       });
-      if (tag === 'div') {
-        Object.defineProperty(el, 'innerHTML', {
-          set() { innerHTMLUsed = true; },
+      if (tag === "div") {
+        Object.defineProperty(el, "innerHTML", {
+          set() {
+            innerHTMLUsed = true;
+          },
         });
       }
-      if (tag === 'span') spans.push(el);
+      if (tag === "span") spans.push(el);
       return el;
     },
     querySelector: (selector) => {
       const m = /\[data-host="([^"]+)"\]/.exec(selector);
       if (m) {
-        return spans.find((s) => s.attrs['data-host'] === m[1]) || dummy();
+        return spans.find((s) => s.attrs["data-host"] === m[1]) || dummy();
       }
       return dummy();
     },
   };
-  const location = new URL('https://example.com/' + query);
+  const location = new URL("https://example.com/" + query);
   const env = {
     window: undefined,
     document,
@@ -129,8 +151,12 @@ function setupSpy(query, data, hooks = {}) {
     URLSearchParams,
     fetch: () => Promise.resolve({ json: () => Promise.resolve(data) }),
     Image: class {
+      constructor() {
+        this.width = 0;
+        this.height = 0;
+      }
       set src(url) {
-        if (url.includes('blocked')) {
+        if (url.includes("blocked")) {
           this.onerror && this.onerror();
         } else {
           this.onload && this.onload();
@@ -143,15 +169,15 @@ function setupSpy(query, data, hooks = {}) {
   };
   const customWrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories, sanitizeHost, createCategorySection, run, TIMEOUT_MS };`;
   const fn = new Function(
-    'window',
-    'document',
-    'location',
-    'URLSearchParams',
-    'fetch',
-    'Image',
-    'setTimeout',
-    'clearTimeout',
-    'console',
+    "window",
+    "document",
+    "location",
+    "URLSearchParams",
+    "fetch",
+    "Image",
+    "setTimeout",
+    "clearTimeout",
+    "console",
     customWrapper,
   );
   const res = fn(
@@ -168,66 +194,75 @@ function setupSpy(query, data, hooks = {}) {
   return { ...res, spans, summaryEl, innerHTMLUsed: () => innerHTMLUsed };
 }
 
-test('loads categories.json without custom param', async () => {
-  const { loadCategories, getCategories } = setup('', clone(categoriesData));
+test("loads categories.json without custom param", async () => {
+  const { loadCategories, getCategories } = setup("", clone(categoriesData));
   await loadCategories();
   assert.deepStrictEqual(getCategories(), categoriesData);
 });
 
-test('appends custom hosts when query param present', async () => {
-  const custom = ['https://example.com/ad.js'];
+test("appends custom hosts when query param present", async () => {
+  const custom = ["https://example.com/ad.js"];
   const { loadCategories, getCategories } = setup(
-    '?custom=' + encodeURIComponent(custom.join(',')),
+    "?custom=" + encodeURIComponent(custom.join(",")),
     clone(categoriesData),
   );
   await loadCategories();
   const expected = clone(categoriesData);
-  expected.push({ name: 'Custom Hosts', hosts: custom });
+  expected.push({ name: "Custom Hosts", hosts: custom });
   assert.deepStrictEqual(getCategories(), expected);
 });
 
-test('handles custom host containing <script> safely', async () => {
-  const malicious = 'https://example.com/<script>alert(1)</script>.js';
+test("handles custom host containing <script> safely", async () => {
+  const malicious = "https://example.com/<script>alert(1)</script>.js";
   const { loadCategories, spans, innerHTMLUsed } = setupSpy(
-    '?custom=' + encodeURIComponent(malicious),
+    "?custom=" + encodeURIComponent(malicious),
     [],
   );
   await loadCategories();
   assert.strictEqual(innerHTMLUsed(), false);
-  assert.ok(spans.some((s) => s._text === malicious.replace(/^https?:\/\//, '')));
-});
-
-test('sanitizeHost escapes quotes', () => {
-  const { sanitizeHost } = setup('', []);
-  assert.strictEqual(
-    sanitizeHost('https://exa"mple.com/ad.js'),
-    'https://exa&quot;mple.com/ad.js',
+  assert.ok(
+    spans.some((s) => s._text === malicious.replace(/^https?:\/\//, "")),
   );
 });
 
-test('createCategorySection builds host row', () => {
-  const { createCategorySection, spans } = setupSpy('', []);
-  const host = 'https://ad.example.com/script.js';
-  createCategorySection({ name: 'Ads', hosts: [host] });
-  const [hostSpan, statusSpan] = spans;
-  assert.strictEqual(hostSpan._text, 'ad.example.com/script.js');
-  assert.strictEqual(statusSpan.attrs['data-host'], host);
+test("sanitizeHost escapes quotes", () => {
+  const { sanitizeHost } = setup("", []);
+  assert.strictEqual(
+    sanitizeHost('https://exa"mple.com/ad.js'),
+    "https://exa&quot;mple.com/ad.js",
+  );
 });
 
-test('run summarizes blocked and allowed hosts', async () => {
+test("createCategorySection builds host row", () => {
+  const { createCategorySection, spans } = setupSpy("", []);
+  const host = "https://ad.example.com/script.js";
+  createCategorySection({ name: "Ads", hosts: [host] });
+  const [hostSpan, statusSpan] = spans;
+  assert.strictEqual(hostSpan._text, "ad.example.com/script.js");
+  assert.strictEqual(statusSpan.attrs["data-host"], host);
+});
+
+test("run summarizes blocked and allowed hosts", async () => {
   const data = [
-    { name: 'Test', hosts: ['https://blocked.com/a.js', 'https://allowed.com/b.js'] },
+    {
+      name: "Test",
+      hosts: ["https://blocked.com/a.js", "https://allowed.com/b.js"],
+    },
   ];
-  const { loadCategories, run, spans, summaryEl } = setupSpy('', data);
+  const { loadCategories, run, spans, summaryEl } = setupSpy("", data);
   // custom Image implementation: block URLs containing "blocked"
   await loadCategories();
   await run();
-  const statusSpans = spans.filter((s) => 'data-host' in s.attrs);
-  const blockedSpan = statusSpans.find((s) => s.attrs['data-host'].includes('blocked'));
-  const allowedSpan = statusSpans.find((s) => s.attrs['data-host'].includes('allowed'));
-  assert.strictEqual(blockedSpan._text, 'Blocked');
-  assert.ok(blockedSpan.classList.added.includes('ok'));
-  assert.strictEqual(allowedSpan._text, 'Allowed');
-  assert.ok(allowedSpan.classList.added.includes('fail'));
-  assert.strictEqual(summaryEl.textContent, 'Blocked 1 / 2 (50%)');
+  const statusSpans = spans.filter((s) => "data-host" in s.attrs);
+  const blockedSpan = statusSpans.find((s) =>
+    s.attrs["data-host"].includes("blocked"),
+  );
+  const allowedSpan = statusSpans.find((s) =>
+    s.attrs["data-host"].includes("allowed"),
+  );
+  assert.strictEqual(blockedSpan._text, "Blocked");
+  assert.ok(blockedSpan.classList.added.includes("ok"));
+  assert.strictEqual(allowedSpan._text, "Allowed");
+  assert.ok(allowedSpan.classList.added.includes("fail"));
+  assert.strictEqual(summaryEl.textContent, "Blocked 1 / 2 (50%)");
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ const root = __dirname ? path.resolve(__dirname, '..') : '..';
 const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const script = /<script>([\s\S]*?)<\/script>/.exec(html)[1];
 const cleaned = script.replace(/loadCategories\(\)\.then\(run\);/, '');
-const wrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories };`;
+const wrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories, sanitizeHost, createCategorySection, run, TIMEOUT_MS };`;
 
 const dummy = () => ({
   appendChild() {},
@@ -34,7 +34,15 @@ function setup(query, data) {
     location,
     URLSearchParams,
     fetch: () => Promise.resolve({ json: () => Promise.resolve(data) }),
-    Image: class { set src(_) { this.onload && this.onload(); } },
+    Image: class {
+      set src(url) {
+        if (url.includes('blocked')) {
+          this.onerror && this.onerror();
+        } else {
+          this.onload && this.onload();
+        }
+      }
+    },
     setTimeout,
     clearTimeout,
     console,
@@ -75,13 +83,21 @@ function clone(obj) {
 function setupSpy(query, data, hooks = {}) {
   let spans = [];
   let innerHTMLUsed = false;
+  const summaryEl = dummy();
+  Object.defineProperty(summaryEl, 'textContent', {
+    set(v) { summaryEl._text = v; },
+    get() { return summaryEl._text; },
+  });
   const document = {
-    getElementById: () => dummy(),
+    getElementById: (id) => (id === 'summary' ? summaryEl : dummy()),
     createElement: (tag) => {
       const el = {
         tag,
         attrs: {},
-        classList: { add() {} },
+        classList: {
+          added: [],
+          add(c) { this.added.push(c); },
+        },
         appendChild() {},
         setAttribute(name, value) { this.attrs[name] = value; },
       };
@@ -97,7 +113,13 @@ function setupSpy(query, data, hooks = {}) {
       if (tag === 'span') spans.push(el);
       return el;
     },
-    querySelector: () => dummy(),
+    querySelector: (selector) => {
+      const m = /\[data-host="([^"]+)"\]/.exec(selector);
+      if (m) {
+        return spans.find((s) => s.attrs['data-host'] === m[1]) || dummy();
+      }
+      return dummy();
+    },
   };
   const location = new URL('https://example.com/' + query);
   const env = {
@@ -106,12 +128,20 @@ function setupSpy(query, data, hooks = {}) {
     location,
     URLSearchParams,
     fetch: () => Promise.resolve({ json: () => Promise.resolve(data) }),
-    Image: class { set src(_) { this.onload && this.onload(); } },
+    Image: class {
+      set src(url) {
+        if (url.includes('blocked')) {
+          this.onerror && this.onerror();
+        } else {
+          this.onload && this.onload();
+        }
+      }
+    },
     setTimeout,
     clearTimeout,
     console,
   };
-  const customWrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories };`;
+  const customWrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories, sanitizeHost, createCategorySection, run, TIMEOUT_MS };`;
   const fn = new Function(
     'window',
     'document',
@@ -135,7 +165,7 @@ function setupSpy(query, data, hooks = {}) {
     env.clearTimeout,
     env.console,
   );
-  return { ...res, spans, innerHTMLUsed: () => innerHTMLUsed };
+  return { ...res, spans, summaryEl, innerHTMLUsed: () => innerHTMLUsed };
 }
 
 test('loads categories.json without custom param', async () => {
@@ -165,4 +195,39 @@ test('handles custom host containing <script> safely', async () => {
   await loadCategories();
   assert.strictEqual(innerHTMLUsed(), false);
   assert.ok(spans.some((s) => s._text === malicious.replace(/^https?:\/\//, '')));
+});
+
+test('sanitizeHost escapes quotes', () => {
+  const { sanitizeHost } = setup('', []);
+  assert.strictEqual(
+    sanitizeHost('https://exa"mple.com/ad.js'),
+    'https://exa&quot;mple.com/ad.js',
+  );
+});
+
+test('createCategorySection builds host row', () => {
+  const { createCategorySection, spans } = setupSpy('', []);
+  const host = 'https://ad.example.com/script.js';
+  createCategorySection({ name: 'Ads', hosts: [host] });
+  const [hostSpan, statusSpan] = spans;
+  assert.strictEqual(hostSpan._text, 'ad.example.com/script.js');
+  assert.strictEqual(statusSpan.attrs['data-host'], host);
+});
+
+test('run summarizes blocked and allowed hosts', async () => {
+  const data = [
+    { name: 'Test', hosts: ['https://blocked.com/a.js', 'https://allowed.com/b.js'] },
+  ];
+  const { loadCategories, run, spans, summaryEl } = setupSpy('', data);
+  // custom Image implementation: block URLs containing "blocked"
+  await loadCategories();
+  await run();
+  const statusSpans = spans.filter((s) => 'data-host' in s.attrs);
+  const blockedSpan = statusSpans.find((s) => s.attrs['data-host'].includes('blocked'));
+  const allowedSpan = statusSpans.find((s) => s.attrs['data-host'].includes('allowed'));
+  assert.strictEqual(blockedSpan._text, 'Blocked');
+  assert.ok(blockedSpan.classList.added.includes('ok'));
+  assert.strictEqual(allowedSpan._text, 'Allowed');
+  assert.ok(allowedSpan.classList.added.includes('fail'));
+  assert.strictEqual(summaryEl.textContent, 'Blocked 1 / 2 (50%)');
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -252,6 +252,13 @@ test("TIMEOUT_MS accepts query param", () => {
   assert.strictEqual(TIMEOUT_MS, 1500);
 });
 
+test("TIMEOUT_MS ignores invalid values", () => {
+  const { TIMEOUT_MS: bad } = setup("?timeout=foo", []);
+  const { TIMEOUT_MS: negative } = setup("?timeout=-10", []);
+  assert.strictEqual(bad, 5000);
+  assert.strictEqual(negative, 5000);
+});
+
 test("custom hosts trim spaces", async () => {
   const hosts = [
     "https://x.com/a.js",


### PR DESCRIPTION
## Summary
- return more utilities from script to enable deeper testing
- add DOM inspection helpers in tests
- add new tests for sanitizer, DOM creation, and run metrics

## Testing
- `node --test test/index.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686a841bc0948333aafab83576f4ae53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for utility functions and UI updates related to host blocking status.
  * Improved mock DOM environment to better simulate image loading, CSS class changes, and text content updates.
  * Added tests to verify safe handling of potentially malicious input and correct escaping in URLs.
  * Enhanced assertions to ensure no unsafe HTML insertion occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->