### PR TITLE
Add tests for run and parser with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - run: pytest -q

--- a/test/python/test_update_categories.py
+++ b/test/python/test_update_categories.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+import types
+sys.modules['requests'] = types.ModuleType('requests')
+from scripts.update_categories import _parse_lines
+
+
+def test_parse_lines_basic():
+    lines = [
+        "0.0.0.0 ads.example.com",
+        "127.0.0.1 tracker.example.com",
+        "||img.example.com^$third-party",
+        "||scripts.example.com/path/file.js",
+        "",
+        "# comment",
+        "! another comment",
+    ]
+    expected = [
+        "https://ads.example.com",
+        "https://tracker.example.com",
+        "https://img.example.com",
+        "https://scripts.example.com",
+    ]
+    assert _parse_lines(lines) == expected


### PR DESCRIPTION
## Summary
- test run() reporting with Node's test framework
- add unit tests for _parse_lines
- run Node and Python tests via GitHub Actions

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a7d41e1008333a8b45897ec68d3d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a continuous integration workflow that automatically runs Node.js and Python tests on pull requests.

* **Tests**
  * Enhanced test setup for more realistic DOM and image simulation.
  * Added a new test to verify host status reporting and summary calculations.
  * Added a Python test to validate URL parsing and normalization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->