### PR TITLE
Fix social list download URL

### DIFF
--- a/scripts/update_categories.py
+++ b/scripts/update_categories.py
@@ -22,6 +22,7 @@ CATEGORY_SOURCES = {
     ],
     "Social Widgets": [
         "https://raw.githubusercontent.com/easylist/easylist/master/easylist/easylist_social.txt",
+        "https://raw.githubusercontent.com/easylist/easylist/master/fanboy-addon/fanboy_social_general_block.txt",
     ],
 }
 


### PR DESCRIPTION
## Summary
- update `scripts/update_categories.py` with a more reliable social widget list URL

## Testing
- `npm test` *(fails: c8 not found)*
- `pytest -q`
- `mypy scripts/update_categories.py` *(fails: missing types-requests)*
- `bandit scripts/update_categories.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac4531984833397aa5ccb9e825321