### PR TITLE
Fix update workflow node deps

### DIFF
--- a/.github/workflows/update_categories.yml
+++ b/.github/workflows/update_categories.yml
@@ -16,8 +16,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+          pip install -r requirements.txt
       - name: Update categories
         run: python scripts/update_categories.py
       - name: Run tests


### PR DESCRIPTION
## Summary
- install Node.js dependencies in the update job to enable tests

## Testing
- `npm test` *(fails: c8 not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686acba490c883338897af96c2bfa8ed