### PR TITLE
Fix update workflow push

### DIFF
--- a/.github/workflows/update_categories.yml
+++ b/.github/workflows/update_categories.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow the scheduled update job to push commits

## Testing
- `npm test` *(fails: `c8: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686accde68008333822d5155779cfe4b