### PR TITLE
Update categories workflow tests

### DIFF
--- a/.github/workflows/update_categories.yml
+++ b/.github/workflows/update_categories.yml
@@ -30,11 +30,13 @@ jobs:
           else
             npm install
           fi
-          pip install -r requirements.txt
+          pip install -r requirements.txt pytest
       - name: Update categories
         run: python scripts/update_categories.py
-      - name: Run tests
+      - name: Run Node tests
         run: npm test
+      - name: Run Python tests
+        run: pytest
       - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ npm run update-categories
 The script fetches several EasyList sources, extracts the hostnames and writes
 them to `categories.json`. A network connection is required when running it.
 
+An automated workflow in `.github/workflows/update_categories.yml` performs the
+same update every week. If the categories change, it runs the tests and commits
+the results so the Pages site is rebuilt.
+
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- run Python tests alongside Node tests after updating categories
- note weekly workflow in documentation

## Testing
- `pytest`
- `npm test` *(fails: c8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad009f85c8333b8d98164e4cdba95