### PR TITLE
Update categories workflow deploys pages

### DIFF
--- a/.github/workflows/update_categories.yml
+++ b/.github/workflows/update_categories.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   update:
@@ -45,3 +47,10 @@ jobs:
             git add categories.json
             git commit -m "chore: update categories" && git push
           fi
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The script fetches several EasyList sources, extracts the hostnames and writes
 them to `categories.json`. A network connection is required when running it.
 
 An automated workflow in `.github/workflows/update_categories.yml` performs the
-same update every week. If the categories change, it runs the tests and commits
-the results so the Pages site is rebuilt.
+same update every week. After regenerating `categories.json`, it runs the tests
+and, on success, publishes the site so the tester is always up to date.
 
 
 ## Running Tests


### PR DESCRIPTION
## Summary
- document that the categories workflow pushes the site weekly
- publish the GitHub Pages site directly from the categories update workflow

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686ad35d7cd08333a2bee2dc66fed225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow to enable direct publishing of the site to GitHub Pages after successful tests.
  * Clarified the workflow behavior in the documentation to reflect the new publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->