### PR TITLE
Update categories workflow to trigger standard CI

### DIFF
--- a/.github/workflows/update_categories.yml
+++ b/.github/workflows/update_categories.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 jobs:
   update:
@@ -21,24 +19,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
       - name: Install dependencies
         run: |
-          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
-            npm ci
-          else
-            npm install
-          fi
-          pip install -r requirements.txt pytest
+          pip install -r requirements.txt
       - name: Update categories
         run: python scripts/update_categories.py
-      - name: Run Node tests
-        run: npm test
-      - name: Run Python tests
-        run: pytest
       - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"
@@ -47,10 +32,3 @@ jobs:
             git add categories.json
             git commit -m "chore: update categories" && git push
           fi
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: '.'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ The script fetches several EasyList sources, extracts the hostnames and writes
 them to `categories.json`. A network connection is required when running it.
 
 An automated workflow in `.github/workflows/update_categories.yml` performs the
-same update every week. After regenerating `categories.json`, it runs the tests
-and, on success, publishes the site so the tester is always up to date.
+same update every week. After regenerating `categories.json`, it pushes the
+changes so the regular CI/CD pipeline can run the tests and publish the site
+if everything passes.
 
 
 ## Running Tests


### PR DESCRIPTION
## Summary
- streamline automated category update job
- document how the update workflow now pushes changes to run CI

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ad72ab1688333a064228986eb1ed4