### PR TITLE
Implement caching for ad test page

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,6 +165,46 @@
     const customHostsInput = document.getElementById('customHostsInput');
     const applyBtn = document.getElementById('applyTimeout');
     const progressBar = document.getElementById('progressBar');
+
+    const CACHE_KEY = 'adTestCache';
+    const CACHE_MS = 3600_000; // one hour
+
+    const saveCache = () => {
+      try {
+        localStorage.setItem(
+          CACHE_KEY,
+          JSON.stringify({
+            ts: Date.now(),
+            results: resultsEl.innerHTML,
+            extra: document.getElementById('extraResults').innerHTML,
+            summary: document.getElementById('summary').textContent,
+            pct: document.getElementById('scoreMeter').value,
+          })
+        );
+      } catch {}
+    };
+
+    const restoreCache = () => {
+      try {
+        const data = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+        if (data && Date.now() - data.ts < CACHE_MS) {
+          resultsEl.innerHTML = data.results;
+          document.getElementById('extraResults').innerHTML = data.extra;
+          document.getElementById('summary').textContent = data.summary;
+          const meter = document.getElementById('scoreMeter');
+          if (meter) meter.value = data.pct;
+          progressBar.style.width = '100%';
+          const notice = document.createElement('div');
+          notice.textContent = 'Results cached. Refresh to re‑run.';
+          notice.style.textAlign = 'center';
+          notice.style.fontSize = '.85rem';
+          document.getElementById('controls').after(notice);
+          runExtraTests();
+          return true;
+        }
+      } catch {}
+      return false;
+    };
     timeoutInput.value = TIMEOUT_MS;
     const customParam = params.get('custom') || '';
     customHostsInput.value = customParam;
@@ -343,7 +383,11 @@
       runExtraTests();
     };
 
-    loadCategories().then(run);
+    loadCategories().then(async () => {
+      if (restoreCache()) return;
+      await run();
+      saveCache();
+    }); //INIT
   </script>
 </body>
 </html>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,7 @@ const { test } = require("node:test");
 const root = __dirname ? path.resolve(__dirname, "..") : "..";
 const html = fs.readFileSync(path.join(root, "index.html"), "utf8");
 const script = /<script>([\s\S]*?)<\/script>/.exec(html)[1];
-const cleaned = script.replace(/loadCategories\(\)\.then\(run\);/, "");
+const cleaned = script.replace(/loadCategories\(\)[\s\S]*?\/\/INIT/, "");
 const wrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories, sanitizeHost, createCategorySection, createExtraSection, runExtraTests, run, testHost, TIMEOUT_MS };\n//# sourceURL=index.inline.js`;
 
 const dummy = () => ({
@@ -59,6 +59,12 @@ function setup(query, data, hooks = {}) {
     setTimeout: hooks.setTimeout || setTimeout,
     clearTimeout: hooks.clearTimeout || clearTimeout,
     console,
+    localStorage: {
+      storage: {},
+      getItem(k) { return this.storage[k]; },
+      setItem(k, v) { this.storage[k] = v; },
+      removeItem(k) { delete this.storage[k]; },
+    },
   };
   const fn = new Function(
     "window",
@@ -70,6 +76,7 @@ function setup(query, data, hooks = {}) {
     "setTimeout",
     "clearTimeout",
     "console",
+    "localStorage",
     wrapper,
   );
   return fn(
@@ -82,6 +89,7 @@ function setup(query, data, hooks = {}) {
     env.setTimeout,
     env.clearTimeout,
     env.console,
+    env.localStorage,
   );
 }
 
@@ -187,6 +195,12 @@ function setupSpy(query, data, hooks = {}) {
     setTimeout: hooks.setTimeout || setTimeout,
     clearTimeout: hooks.clearTimeout || clearTimeout,
     console,
+    localStorage: {
+      storage: {},
+      getItem(k) { return this.storage[k]; },
+      setItem(k, v) { this.storage[k] = v; },
+      removeItem(k) { delete this.storage[k]; },
+    },
   };
   const customWrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories, sanitizeHost, createCategorySection, createExtraSection, runExtraTests, run, testHost, TIMEOUT_MS };\n//# sourceURL=index.inline.js`;
   const fn = new Function(
@@ -199,6 +213,7 @@ function setupSpy(query, data, hooks = {}) {
     "setTimeout",
     "clearTimeout",
     "console",
+    "localStorage",
     customWrapper,
   );
   const res = fn(
@@ -211,6 +226,7 @@ function setupSpy(query, data, hooks = {}) {
     env.setTimeout,
     env.clearTimeout,
     env.console,
+    env.localStorage,
   );
   return { ...res, spans, divs, summaryEl, innerHTMLUsed: () => innerHTMLUsed, env };
 }


### PR DESCRIPTION
## Summary
- add client-side caching so the ad test only reruns once per hour
- update Node tests to handle new init block and localStorage

## Testing
- `node --test`
- `pytest -q --maxfail=1 --disable-warnings`
- `npm test` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686ae860e8dc83339c8ab905339c333a