### PR TITLE
Add copy results button to ad test page

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,6 +190,7 @@
         <input id="customHostsInput" placeholder="https://example.com/ad.js"
       /></label>
       <button id="applyTimeout">Run Test</button>
+      <button id="copyResults" disabled>Copy Results</button>
     </div>
     <div id="results"></div>
     <div id="summary"></div>
@@ -212,6 +213,7 @@
       let categories = [];
       const wheelMap = new Map();
       const logMap = new Map();
+      let resultsSummary = "";
 
       const extraTests = [
         {
@@ -255,6 +257,7 @@
       const customHostsInput = document.getElementById("customHostsInput");
       const applyBtn = document.getElementById("applyTimeout");
       const progressBar = document.getElementById("progressBar");
+      const copyBtn = document.getElementById("copyResults");
       timeoutInput.value = TIMEOUT_MS;
       const customParam = params.get("custom") || "";
       customHostsInput.value = customParam;
@@ -271,6 +274,18 @@
         }
         location.href = url.toString();
       });
+
+      if (copyBtn && typeof navigator !== "undefined" && navigator.clipboard) {
+        copyBtn.addEventListener("click", () => {
+          navigator.clipboard.writeText(resultsSummary).then(() => {
+            const original = copyBtn.textContent;
+            copyBtn.textContent = "Copied!";
+            setTimeout(() => {
+              copyBtn.textContent = original;
+            }, 1000);
+          });
+        });
+      }
 
       const sanitizeHost = (host) => host.replace(/"/g, "&quot;");
 
@@ -438,7 +453,10 @@
         const summary = document.getElementById("summary");
         const meter = document.getElementById("scoreMeter");
         if (meter) meter.value = pct;
-        summary.textContent = `Blocked ${blocked} / ${tested} (${pct}%)`;
+        const text = `Blocked ${blocked} / ${tested} (${pct}%)`;
+        summary.textContent = text;
+        resultsSummary = text;
+        if (copyBtn) copyBtn.disabled = false;
         progressBar.style.width = "100%";
         progressBar.style.display = "flex";
         progressBar.style.alignItems = "center";

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,7 +8,7 @@ const root = __dirname ? path.resolve(__dirname, "..") : "..";
 const html = fs.readFileSync(path.join(root, "index.html"), "utf8");
 const script = /<script>([\s\S]*?)<\/script>/.exec(html)[1];
 const cleaned = script.replace(/loadCategories\(\)\.then\(run\);/, "");
-const wrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories, sanitizeHost, createCategorySection, createExtraSection, runExtraTests, run, testHost, TIMEOUT_MS };\n//# sourceURL=index.inline.js`;
+const wrapper = `${cleaned}\nreturn { loadCategories, getCategories: () => categories, sanitizeHost, createCategorySection, createExtraSection, runExtraTests, run, testHost, TIMEOUT_MS, getSummary: () => resultsSummary };\n//# sourceURL=index.inline.js`;
 
 const dummy = () => ({
   childNodes: [],
@@ -325,6 +325,16 @@ test("run summarizes blocked and allowed hosts", async () => {
   assert.ok(statuses.includes("Blocked"));
   assert.ok(statuses.includes("Allowed"));
   assert.strictEqual(summaryEl.textContent, "Blocked 1 / 2 (50%)");
+});
+
+test("getSummary returns last summary", async () => {
+  const data = [
+    { name: "Test", hosts: ["https://blocked.com/a.js"] },
+  ];
+  const { loadCategories, run, getSummary } = setup("", data);
+  await loadCategories();
+  await run();
+  assert.strictEqual(getSummary(), "Blocked 1 / 1 (100%)");
 });
 
 test("testHost resolves false on load", async () => {


### PR DESCRIPTION
## Summary
- add a Copy Results button to the ad-block test page
- expose summary via `getSummary()` for tests
- test new helper

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aec3aadcc8333abee729469526c44