### PR TITLE
Extend prime host list

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -73,7 +73,17 @@
       "https://www.shopify.com",
       "https://www.usa.gov",
       "https://www.xnxx.com",
-      "https://www.youtube.com"
+      "https://www.youtube.com",
+      "https://ajax.googleapis.com",
+      "https://fonts.googleapis.com",
+      "https://fonts.gstatic.com",
+      "https://code.jquery.com",
+      "https://cdn.polyfill.io",
+      "https://cdn.datadoghq.com",
+      "https://cdn.syndication.twimg.com",
+      "https://cdn.sstatic.net",
+      "https://cdn.onesignal.com",
+      "https://unpkg.com"
     ]
   },
 


### PR DESCRIPTION
## Summary
- extend prime host list with common CDNs and libraries

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aef95e2688333b3ab1e6841a74537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several new URLs to the "Prime" category, expanding the list of supported hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->