### PR TITLE
Add Software WebGL detection

### DIFF
--- a/bots.html
+++ b/bots.html
@@ -134,6 +134,23 @@
           },
         },
         {
+          name: "Software WebGL",
+          fn: () => {
+            try {
+              const c = document.createElement("canvas");
+              const gl = c.getContext("webgl") || c.getContext("experimental-webgl");
+              if (!gl) return false;
+              const dbg = gl.getExtension("WEBGL_debug_renderer_info");
+              const renderer = dbg
+                ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)
+                : gl.getParameter(gl.RENDERER);
+              return /swiftshader|llvmpipe/i.test(renderer);
+            } catch (e) {
+              return false;
+            }
+          },
+        },
+        {
           name: "Touch on desktop",
           fn: () =>
             "ontouchstart" in window &&

--- a/fingerprint.html
+++ b/fingerprint.html
@@ -121,6 +121,10 @@
         }
       }
 
+      function isSoftwareWebGL(renderer) {
+        return /swiftshader|llvmpipe/i.test(renderer || "");
+      }
+
       const { vendor: webglVendor, renderer: webglRenderer } = getWebGLInfo();
 
       const data = {
@@ -143,6 +147,7 @@
         "Canvas Hash": getCanvasHash(),
         "WebGL Vendor": webglVendor,
         "WebGL Renderer": webglRenderer,
+        "Software WebGL": isSoftwareWebGL(webglRenderer),
       };
       const container = document.getElementById("fp");
       const dl = document.createElement("dl");

--- a/test/bots.test.js
+++ b/test/bots.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { test } = require('node:test');
+
+const root = __dirname ? path.resolve(__dirname, '..') : '..';
+const html = fs.readFileSync(path.join(root, 'bots.html'), 'utf8');
+const script = /<script>([\s\S]*?)<\/script>/.exec(html)[1];
+
+// simple test to verify Software WebGL check present
+
+test('bots page includes software WebGL check', () => {
+  assert.ok(/Software WebGL/.test(script));
+});


### PR DESCRIPTION
## Summary
- add a new bot check for software-based WebGL renderers
- expose the same info in the fingerprint page
- test that the bot page script contains the new check

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686af22513048333a6ebebd92172b327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Software WebGL" check to detect software-based WebGL renderers in bot detection.
  * Included a "Software WebGL" indicator in browser fingerprint data to show if a software renderer is used.

* **Tests**
  * Introduced a test to verify the presence of the "Software WebGL" check in the bot detection page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->