### PR TITLE
Add bot detection checks

### DIFF
--- a/bots.html
+++ b/bots.html
@@ -119,6 +119,11 @@
         },
         { name: "Cookies disabled", fn: () => !navigator.cookieEnabled },
         {
+          name: "Missing permissions API",
+          fn: () => !navigator.permissions,
+        },
+        { name: "No Chrome object", fn: () => !window.chrome },
+        {
           name: "Low hardware cores",
           fn: () => navigator.hardwareConcurrency && navigator.hardwareConcurrency < 2,
         },

--- a/test/bots.test.js
+++ b/test/bots.test.js
@@ -1,0 +1,71 @@
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const { test } = require("node:test");
+
+const root = __dirname ? path.resolve(__dirname, "..") : "..";
+const html = fs.readFileSync(path.join(root, "bots.html"), "utf8");
+const script = /<script>([\s\S]*?)<\/script>/.exec(html)[1];
+const wrapper = `${script}\nreturn { checks, flagged };\n//# sourceURL=bots.inline.js`;
+
+function createEl(tag) {
+  return {
+    tag,
+    children: [],
+    className: "",
+    appendChild(node) {
+      this.children.push(node);
+    },
+    set textContent(v) {
+      this._text = v;
+    },
+    get textContent() {
+      return this._text;
+    },
+    getContext() {
+      return {};
+    },
+  };
+}
+
+function setup(navigatorProps = {}, windowProps = {}) {
+  const resultsEl = createEl("div");
+  const summaryEl = createEl("div");
+  const document = {
+    createElement: createEl,
+    getElementById(id) {
+      if (id === "results") return resultsEl;
+      if (id === "summary") return summaryEl;
+      return createEl("div");
+    },
+  };
+  const navigatorObj = Object.assign(
+    {
+      webdriver: false,
+      userAgent: "Mozilla",
+      plugins: { length: 1 },
+      languages: ["en"],
+      cookieEnabled: true,
+      hardwareConcurrency: 4,
+      permissions: {},
+    },
+    navigatorProps,
+  );
+  const windowObj = Object.assign({}, windowProps);
+  const fn = new Function("navigator", "window", "document", wrapper);
+  const res = fn(navigatorObj, windowObj, document);
+  res.summary = summaryEl.textContent;
+  return res;
+}
+
+test("includes new checks", () => {
+  const { checks } = setup();
+  const names = checks.map((c) => c.name);
+  assert.ok(names.includes("Missing permissions API"));
+  assert.ok(names.includes("No Chrome object"));
+});
+
+test("flags when permissions and chrome missing", () => {
+  const { flagged } = setup({ permissions: undefined }, { chrome: undefined });
+  assert.strictEqual(flagged, 2);
+});


### PR DESCRIPTION
## Summary
- extend bots page with a missing permissions API and Chrome object checks
- test bot detection logic

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af164c3bc8333aaca6c652ef23397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bot detection with two additional heuristic checks for improved accuracy.

* **Tests**
  * Added new tests to verify the presence and correct functioning of the new bot detection checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->