### PR TITLE
Add BotD detection to bots page

### DIFF
--- a/bots.html
+++ b/bots.html
@@ -105,6 +105,7 @@
     <h1>Bot Detection</h1>
     <div id="results"></div>
     <div id="summary"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@fingerprintjs/botd@3/dist/botd.min.js"></script>
     <script>
       const checks = [
         { name: "navigator.webdriver", fn: () => navigator.webdriver },
@@ -185,6 +186,29 @@
         resultsEl.appendChild(row);
       });
       summaryEl.textContent = `${flagged} suspicious flag${flagged === 1 ? "" : "s"} detected`;
+
+      if (window.Botd && window.Botd.load) {
+        window.Botd.load()
+          .then((botd) => botd.detect())
+          .then((r) => {
+            const row = document.createElement("div");
+            row.className = "check";
+            const name = document.createElement("span");
+            name.textContent = "BotD";
+            const status = document.createElement("span");
+            const res = r.bot;
+            if (res) flagged += 1;
+            status.textContent = res ? "Bot" : "Human";
+            status.className =
+              "status badge " + (res ? "fail badge--fail" : "ok badge--ok");
+            row.appendChild(name);
+            row.appendChild(status);
+            resultsEl.appendChild(row);
+            summaryEl.textContent = `${flagged} suspicious flag${
+              flagged === 1 ? "" : "s"
+            } detected`;
+          });
+      }
     </script>
   </body>
 </html>

--- a/test/bots.test.js
+++ b/test/bots.test.js
@@ -90,3 +90,21 @@ test("flags software WebGL renderer", () => {
   );
   assert.strictEqual(flagged, 1);
 });
+
+test("calls BotD when available", () => {
+  let called = false;
+  setup(
+    {},
+    {
+      Botd: {
+        load: () => {
+          called = true;
+          return Promise.resolve({
+            detect: () => Promise.resolve({ bot: false }),
+          });
+        },
+      },
+    },
+  );
+  assert.ok(called);
+});


### PR DESCRIPTION
## Summary
- embed BotD script on the bots page
- run BotD detection and display result
- test that BotD gets called when present

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b11393f5c8333aebe6575efe092ce