### PR TITLE
Improve layout for widescreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
       h1 {
         margin: 0 0 0.5rem;
         text-align: center;
-        font-size: clamp(1.5rem, 5vw, 2rem);
+        font-size: clamp(1.75rem, 5vw, 3rem);
       }
       .category {
         background: var(--bg-light);
@@ -119,9 +119,22 @@
       .badge--fail {
         background: var(--warn-red);
       }
-      #results {
+      #results,
+      #extraResults {
         flex: 1 1 auto;
         overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      @media (min-width: 700px) {
+        #results,
+        #extraResults {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+          align-content: start;
+        }
       }
       #summary {
         text-align: center;


### PR DESCRIPTION
## Summary
- adjust heading size for large screens
- add grid layout for results and extra results containers when viewport is wide

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b0fd7657c833384944d705f2a544a