### PR TITLE
Fix fingerprint page blank layout

### DIFF
--- a/fingerprint.html
+++ b/fingerprint.html
@@ -20,7 +20,6 @@
         display: flex;
         flex-direction: column;
         height: 100vh;
-        overflow: hidden;
         gap: 1rem;
       }
       nav {
@@ -43,16 +42,21 @@
       }
       #fp {
         flex: 1 1 auto;
-        overflow: hidden;
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        column-gap: 0.5rem;
+        row-gap: 0.25rem;
+        font-size: 0.8rem;
       }
       dl {
         margin: 0;
+        display: contents;
       }
       dt {
         font-weight: 600;
       }
       dd {
-        margin: 0 0 0.5rem 0;
+        margin: 0;
         word-break: break-all;
       }
       footer {


### PR DESCRIPTION
## Summary
- adjust fingerprint page to use grid layout
- remove overflow style that hid page contents

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686b159e508c8333946e0b1824b0c790