### PR TITLE
Add additional adblock detection tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,33 @@
         })
         .catch(() => {});
     </script>
+    <script id="ws-bait">
+      try {
+        new WebSocket("wss://example.com/ad");
+        window.__wsBaitLoaded = true;
+      } catch (e) {}
+    </script>
+    <script id="storage-bait">
+      try {
+        localStorage.setItem("ad-test", "1");
+        window.__storageBaitLoaded = localStorage.getItem("ad-test") === "1";
+        localStorage.removeItem("ad-test");
+      } catch (e) {}
+    </script>
+    <script id="css-bait">
+      try {
+        const style = document.createElement("style");
+        style.textContent = ".ad-css-bait{color:rgb(1,2,3)}";
+        document.head.appendChild(style);
+        const div = document.createElement("div");
+        div.className = "ad-css-bait";
+        document.body.appendChild(div);
+        const applied = getComputedStyle(div).color === "rgb(1, 2, 3)";
+        style.remove();
+        div.remove();
+        if (applied) window.__cssBaitLoaded = true;
+      } catch (e) {}
+    </script>
     <iframe
       id="iframeBait"
       style="width: 1px; height: 1px; position: absolute; left: -9999px"
@@ -302,6 +329,24 @@
           group: "Network",
           name: "Fetch Bait",
           isBlocked: () => window.__fetchBaitLoaded !== true,
+        },
+        {
+          id: "ws-bait",
+          group: "Network",
+          name: "WebSocket Bait",
+          isBlocked: () => window.__wsBaitLoaded !== true,
+        },
+        {
+          id: "storage-bait",
+          group: "Storage",
+          name: "Storage Bait",
+          isBlocked: () => window.__storageBaitLoaded !== true,
+        },
+        {
+          id: "css-bait",
+          group: "CSS",
+          name: "CSS Rule Bait",
+          isBlocked: () => window.__cssBaitLoaded !== true,
         },
       ];
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -394,8 +394,8 @@ test("createExtraSection builds extra rows", () => {
   const { createExtraSection, spans } = setupSpy("", []);
   createExtraSection();
   const extras = spans.filter((s) => "data-extra" in s.attrs);
-  // four tests defined in page
-  assert.strictEqual(extras.length, 4);
+  // seven tests defined in page
+  assert.strictEqual(extras.length, 7);
 });
 
 test("runExtraTests reports extra blocks", () => {
@@ -406,6 +406,10 @@ test("runExtraTests reports extra blocks", () => {
   });
   env.window.__adBaitLoaded = undefined;
   env.window.__iframeBaitLoaded = undefined;
+  env.window.__fetchBaitLoaded = undefined;
+  env.window.__wsBaitLoaded = undefined;
+  env.window.__storageBaitLoaded = undefined;
+  env.window.__cssBaitLoaded = undefined;
   createExtraSection();
   runExtraTests();
   const extras = Object.fromEntries(
@@ -421,4 +425,10 @@ test("runExtraTests reports extra blocks", () => {
   assert.ok(extras["iframe-bait"].classList.added.includes("ok"));
   assert.strictEqual(extras["fetch-bait"]._text, "Blocked");
   assert.ok(extras["fetch-bait"].classList.added.includes("ok"));
+  assert.strictEqual(extras["ws-bait"]._text, "Blocked");
+  assert.ok(extras["ws-bait"].classList.added.includes("ok"));
+  assert.strictEqual(extras["storage-bait"]._text, "Blocked");
+  assert.ok(extras["storage-bait"].classList.added.includes("ok"));
+  assert.strictEqual(extras["css-bait"]._text, "Blocked");
+  assert.ok(extras["css-bait"].classList.added.includes("ok"));
 });


### PR DESCRIPTION
## Summary
- test for blocked CSS rules, WebSocket connection, and storage API
- update `index.html` to execute these baits and display results
- adjust unit tests for the new checks

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b15e841188333998452bc078bd672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new ad-block detection tests for WebSocket, localStorage, and CSS rule blocking, providing enhanced detection and reporting in the UI.

* **Tests**
  * Updated and expanded test coverage to include the new WebSocket, storage, and CSS bait detection features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->