### PR TITLE
🌱fix: avoid blank fingerprint page

### DIFF
--- a/fingerprint.html
+++ b/fingerprint.html
@@ -178,10 +178,15 @@
       }
 
       function getPublicIP() {
-        return fetch("https://api.ipify.org?format=json")
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 3000);
+        return fetch("https://api.ipify.org?format=json", {
+          signal: controller.signal,
+        })
           .then((r) => r.json())
           .then((d) => d.ip)
-          .catch(() => "n/a");
+          .catch(() => "n/a")
+          .finally(() => clearTimeout(timeout));
       }
 
       function getLocalIPs() {
@@ -257,11 +262,16 @@
       async function render() {
         const { vendor: webglVendor, renderer: webglRenderer } = getWebGLInfo();
         const { type: connectionType, downlink } = getConnectionInfo();
-        const { level: batteryLevel, charging: batteryCharging } =
-          await getBatteryInfo();
+        const [battery, ip, local, geo] = await Promise.all([
+          getBatteryInfo(),
+          getPublicIP(),
+          getLocalIPs(),
+          getGeo(),
+        ]);
+        const { level: batteryLevel, charging: batteryCharging } = battery;
         const data = {
-          "IP Address": await getPublicIP(),
-          "Local IPs": await getLocalIPs(),
+          "IP Address": ip,
+          "Local IPs": local,
           "User Agent": navigator.userAgent,
           Languages: navigator.languages ? navigator.languages.join(", ") : "",
           Platform: navigator.platform,
@@ -285,7 +295,7 @@
           "WebGL Vendor": webglVendor,
           "WebGL Renderer": webglRenderer,
           Fonts: detectFonts(),
-          Geolocation: await getGeo(),
+          Geolocation: geo,
         };
         const container = document.getElementById("fp");
         const dl = document.createElement("dl");

--- a/test/fingerprint.test.js
+++ b/test/fingerprint.test.js
@@ -6,7 +6,7 @@ const { test } = require("node:test");
 const root = __dirname ? path.resolve(__dirname, "..") : "..";
 const html = fs.readFileSync(path.join(root, "fingerprint.html"), "utf8");
 const script = /<script>([\s\S]*?)<\/script>/.exec(html)[1];
-const wrapper = `${script}\nreturn { getLocalIPs, render };\n//# sourceURL=fingerprint.inline.js`;
+const wrapper = `${script}\nreturn { getLocalIPs, getPublicIP, render };\n//# sourceURL=fingerprint.inline.js`;
 
 function setup(hooks = {}) {
   const env = {
@@ -28,7 +28,7 @@ function setup(hooks = {}) {
       connection: {},
     },
     screen: { width: 1, height: 1, colorDepth: 8 },
-    fetch: () => Promise.resolve({ json: () => ({ ip: "0.0.0.0" }) }),
+    fetch: hooks.fetch || (() => Promise.resolve({ json: () => ({ ip: "0.0.0.0" }) })),
     RTCPeerConnection: hooks.RTCPeerConnection,
   };
   const fn = new Function(
@@ -83,4 +83,27 @@ test("render resolves even when local IP lookup fails", async () => {
     },
   });
   await render();
+});
+
+test("getPublicIP resolves 'n/a' on timeout", async () => {
+  let callback;
+  const originalSetTimeout = global.setTimeout;
+  const originalClearTimeout = global.clearTimeout;
+  global.setTimeout = (fn) => {
+    callback = fn;
+    return 1;
+  };
+  global.clearTimeout = () => {};
+  const { getPublicIP } = setup({
+    fetch: (_, opts) =>
+      new Promise((resolve, reject) => {
+        opts.signal.addEventListener("abort", () => reject(new Error("aborted")));
+      }),
+  });
+  const promise = getPublicIP();
+  callback();
+  const ip = await promise;
+  assert.strictEqual(ip, "n/a");
+  global.setTimeout = originalSetTimeout;
+  global.clearTimeout = originalClearTimeout;
 });


### PR DESCRIPTION
## Summary
- avoid long waits when getting public IP by aborting fetch after 3s
- gather async fingerprint tasks concurrently
- test the new abort logic

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b198510e88333a077a31eb2b704ce