### PR TITLE
Add sensor checks to bots page

### DIFF
--- a/bots.html
+++ b/bots.html
@@ -143,6 +143,9 @@
           fn: () =>
             navigator.hardwareConcurrency && navigator.hardwareConcurrency < 2,
         },
+        { name: "Battery API missing", fn: () => !navigator.getBattery },
+        { name: "No DeviceMotion", fn: () => !window.DeviceMotionEvent },
+        { name: "No HID API", fn: () => !navigator.hid },
         {
           name: "No WebGL",
           fn: () => {

--- a/test/bots.test.js
+++ b/test/bots.test.js
@@ -48,10 +48,12 @@ function setup(navigatorProps = {}, windowProps = {}, docHooks = {}) {
       cookieEnabled: true,
       hardwareConcurrency: 4,
       permissions: {},
+      getBattery: () => Promise.resolve(),
+      hid: {},
     },
     navigatorProps,
   );
-  const windowObj = Object.assign({}, windowProps);
+  const windowObj = Object.assign({ DeviceMotionEvent: function () {}, chrome: {} , hid: {} }, windowProps);
   const fn = new Function("navigator", "window", "document", wrapper);
   const res = fn(navigatorObj, windowObj, document);
   res.summary = summaryEl.textContent;
@@ -64,6 +66,9 @@ test("includes new checks", () => {
   assert.ok(names.includes("Missing permissions API"));
   assert.ok(names.includes("No Chrome object"));
   assert.ok(names.includes("Software WebGL renderer"));
+  assert.ok(names.includes("Battery API missing"));
+  assert.ok(names.includes("No DeviceMotion"));
+  assert.ok(names.includes("No HID API"));
 });
 
 test("flags when permissions and chrome missing", () => {
@@ -89,6 +94,14 @@ test("flags software WebGL renderer", () => {
     },
   );
   assert.strictEqual(flagged, 1);
+});
+
+test("flags missing sensor APIs", () => {
+  const { flagged } = setup(
+    { getBattery: undefined, hid: undefined },
+    { DeviceMotionEvent: undefined, chrome: {} },
+  );
+  assert.strictEqual(flagged, 3);
 });
 
 test("calls BotD when available", () => {


### PR DESCRIPTION
## Summary
- expand bot detection with Battery, DeviceMotion and HID checks
- cover new checks in the test suite

## Testing
- `npm test --silent`
- `pytest -q`
- `black --check .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686bbd220d108333b91aeecc7f1ae7cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new bot detection checks for missing Battery API, DeviceMotion event, and HID API, improving the ability to identify suspicious environments.

* **Tests**
  * Expanded test coverage to include scenarios where these APIs are absent, ensuring accurate detection and reliability of the new checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->